### PR TITLE
Practice 7

### DIFF
--- a/kafka_practice/kafka_generator.py
+++ b/kafka_practice/kafka_generator.py
@@ -1,0 +1,53 @@
+import findspark
+import os
+os.environ['SPARK_KAFKA_VERSION'] = '0.10'
+findspark.init()
+
+import time
+import numpy as np
+import pyspark.sql.functions as F
+import pyspark.sql.types as T
+from pyspark.sql import SparkSession
+
+packages = [
+    f'org.apache.spark:spark-sql-kafka-0-10_2.12:3.0.3',
+    "org.apache.kafka:kafka-clients:0.10.2.12",
+    "org.apache.commons:commons-pool2:2.8.0"
+]
+
+if __name__ == "__main__":
+    spark = SparkSession.builder\
+       .appName("kafka-example")\
+       .master("local[*]")\
+       .config("spark.jars.packages", ",".join(packages))\
+       .config("spark.driver.extraClassPath", "/home/ubuntu/.ivy2/jars/org.apache.kafka_kafka-clients-3.0.0.jar")\
+       .config("spark.executor.extraClassPath", "/home/ubuntu/.ivy2/jars/org.apache.kafka_kafka-clients-3.0.0.jar")\
+       .getOrCreate()
+
+    features = spark.read.parquet("./practice_1/features.parquet")
+    features.cache()
+
+    features_size = features.count()
+    to_array = F.udf(lambda v: v.toArray().tolist(), T.ArrayType(T.FloatType()))
+
+    while True:
+        print("*" * 100)
+        sample_size = np.random.randint(1, min(5, features_size))
+
+
+        data_sample = features.sample(fraction=sample_size / features_size)
+
+        data_sample = data_sample.select(F.to_json(to_array("scaledFeatures")).alias("value"))
+
+        print(f"Writing {sample_size} to inb topic.")
+        data_sample = (
+            data_sample
+            .selectExpr("CAST(value AS STRING)")
+            .write
+            .format("kafka")
+            .option("kafka.bootstrap.servers", "localhost:9092")
+            .option("topic", "inb")
+            .save()
+        )
+        print("Done.")
+

--- a/kafka_practice/kafka_predictions.py
+++ b/kafka_practice/kafka_predictions.py
@@ -1,0 +1,83 @@
+import findspark
+import os
+os.environ['SPARK_KAFKA_VERSION'] = '0.10'
+findspark.init()
+
+import pyspark.sql.functions as F
+import pyspark.sql.types as T
+from pyspark.sql import SparkSession
+
+from pyspark.sql.types import StructType, StructField, ArrayType, FloatType
+from pyspark.ml.linalg import Vectors, VectorUDT
+from pyspark.sql.functions import udf
+import mlflow
+
+OUT_TOPIC = "outb"
+IN_TOPIC = "inb"
+BOOTSTRAP_SERVERS = "localhost:9092"
+PACKAGES = [
+    f'org.apache.spark:spark-sql-kafka-0-10_2.12:3.0.3',
+    "org.apache.kafka:kafka-clients:0.10.2.12",
+    "org.apache.commons:commons-pool2:2.8.0"
+]
+
+# S3 Creds
+os.environ["AWS_ACCESS_KEY_ID"] = ""
+os.environ["AWS_SECRET_ACCESS_KEY"] = ""
+os.environ["MLFLOW_S3_ENDPOINT_URL"] = "https://storage.yandexcloud.net"
+os.environ["AWS_S3_ENDPOINT_URL"] = "https://storage.yandexcloud.net"
+
+if __name__ == "__main__":
+    spark = SparkSession.builder\
+       .appName("kafka-example")\
+       .master("local[*]")\
+       .config("spark.jars.packages", ",".join(PACKAGES))\
+       .config("spark.driver.extraClassPath", "/home/ubuntu/.ivy2/jars/org.apache.kafka_kafka-clients-3.0.0.jar")\
+       .config("spark.executor.extraClassPath", "/home/ubuntu/.ivy2/jars/org.apache.kafka_kafka-clients-3.0.0.jar")\
+       .getOrCreate()
+    mlflow.set_tracking_uri(f"http://localhost:5000")
+
+    print("Getting current production model from MlFlow.")
+    client = mlflow.client.MlflowClient(f"http://localhost:5000")
+    current_prod_model = mlflow.spark.load_model("models:/fraud_detection_model/latest")
+    
+    print(f"Reading requests from '{IN_TOPIC}' topic.")
+    requests_df = (
+        spark
+        .readStream
+        .format("kafka") 
+        .option("kafka.bootstrap.servers", BOOTSTRAP_SERVERS) 
+        .option("failOnDataLoss", "false")
+        .option("subscribe", IN_TOPIC) 
+        .option("startingOffsets", "earliest") 
+        .load()
+        .selectExpr("CAST(value AS STRING)")
+    )
+
+
+    schema = StructType([ 
+        StructField("scaledFeatures", ArrayType(FloatType()), True)
+      ])
+
+    array_from_json = F.udf(lambda v: eval(v), T.ArrayType(T.FloatType()))
+    list_to_vector_udf = udf(lambda l: Vectors.dense(l), VectorUDT())
+
+    requests_df = requests_df.select(list_to_vector_udf(array_from_json(F.col("value"))).alias("scaledFeatures"))
+    requests_df_with_predictions = (
+        current_prod_model
+        .transform(requests_df)
+        .select(
+            F.to_json(F.struct('scaledFeatures', 'rawPrediction', 'probability', 'prediction')).alias("value")
+        )
+    )
+
+    print(f"Writing answers to '{OUT_TOPIC}' topic.")
+    write_predictions_ex = (
+        requests_df_with_predictions
+        .writeStream
+        .format("kafka")
+        .option("checkpointLocation", "./checkpoint/test_2")
+        .option("kafka.bootstrap.servers", "localhost:9092")
+        .option("topic", OUT_TOPIC)
+        .start()
+    )


### PR DESCRIPTION
Added solution of practice_7 (kafka + pyspark streaming). Both (data generator for input topic and inference part) implemented with PySpark. Also, both placed in kafka's topics as JSONs.

Disclaimer: for example i generated already prepared features, in production case we need no preprocess them before making predictions.

Example of generator:
![изображение](https://user-images.githubusercontent.com/64536258/196011796-3011a576-c275-40b9-8a27-2cbecbfb078f.png)

Example of answer:
![изображение](https://user-images.githubusercontent.com/64536258/196011804-02f0972e-7b7b-4e04-b66d-61585403ad43.png)

So, we can see predictions in answer.
